### PR TITLE
Add InstrumentType ANY

### DIFF
--- a/avanza/constants.py
+++ b/avanza/constants.py
@@ -53,7 +53,7 @@ class InstrumentType(enum.Enum):
     SUBSCRIPTION_OPTION = 'subscription_option'
     EQUITY_LINKED_BOND = 'equity_linked_bond'
     CONVERTIBLE = 'convertible'
-
+    ANY = ''
 
 class OrderType(enum.Enum):
     BUY = 'BUY'


### PR DESCRIPTION
Tested that it works with:
```
class tmp: value='';
return avanza.search_for_instrument(tmp, query)
```