### PR TITLE
Add two functions to buy and sell investment funds

### DIFF
--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -1503,6 +1503,61 @@ class Avanza:
             }
         )
 
+    def place_order_buy_fund(
+        self,
+        account_id: str,
+        order_book_id: str,
+        amount: float
+    ):
+        """ Place a buy order for a fund
+
+        Returns:
+            {
+                message: str,
+                orderId: str,
+                accountId: str,
+                orderRequestStatus: str
+            }
+        """
+
+        return self.__call(
+            HttpMethod.POST,
+            Route.ORDER_PLACE_PATH_BUY_FUND.value,
+            {
+                'orderbookId': order_book_id,
+                'accountId': account_id,
+                'amount': amount
+            }
+        )
+
+    def place_order_sell_fund(
+        self,
+        account_id: str,
+        order_book_id: str,
+        volume: float
+    ):
+        """ Place a sell order for a fund
+
+        Returns:
+            {
+                message: str,
+                orderId: str,
+                accountId: str,
+                orderRequestStatus: str
+            }
+        """
+
+        return self.__call(
+            HttpMethod.POST,
+            Route.ORDER_PLACE_PATH_SELL_FUND.value,
+            {
+                'orderbookId': order_book_id,
+                'accountId': account_id,
+                'volume': volume
+            }
+        )
+
+
     def edit_order(
         self,
         instrument_type: InstrumentType,
@@ -1711,7 +1766,7 @@ class Avanza:
     def get_all_monthly_savings(
         self
     ):
-        """ Get your monthly savings at Avanza 
+        """ Get your monthly savings at Avanza
 
         Returns:
             {

--- a/avanza/constants.py
+++ b/avanza/constants.py
@@ -85,6 +85,8 @@ class Route(enum.Enum):
     ORDER_DELETE_PATH = '/_api/order?accountId={}&orderId={}'
     ORDER_GET_PATH = '/_mobile/order/{}?accountId={}&orderId={}'
     ORDER_PLACE_PATH = '/_api/order'
+    ORDER_PLACE_PATH_BUY_FUND = '/_api/fund-guide/fund-order-page/buy'
+    ORDER_PLACE_PATH_SELL_FUND = '/_api/fund-guide/fund-order-page/sell'
     ORDER_EDIT_PATH = '/_api/order/{}/{}'
     ORDERBOOK_LIST_PATH = '/_mobile/market/orderbooklist/{}'
     ORDERBOOK_PATH = '/_mobile/order/{}?orderbookId={}'


### PR DESCRIPTION
This should fix #31 

Adds two new functions:
* `place_order_buy_fund`
* `place_order_sell_fund`

*Example code:*
```
ed = avanza.place_order_buy_fund(
    account_id='<accountid>',
    order_book_id = "56127",
    amount = 1000)
print(json.dumps(ed, indent=2, sort_keys=True))

order = ed["orderId"]

time.sleep(1)

ed = avanza.delete_order(account_id="<accountid>", order_id=order)

print(json.dumps(ed, indent=2, sort_keys=True))

time.sleep(5)

######################################

ed = avanza.place_order_sell_fund(
    account_id='<accountid>',
    order_book_id = "56127",
    volume = 2)
print(json.dumps(ed, indent=2, sort_keys=True))

order = ed["orderId"]

time.sleep(1)

ed = avanza.delete_order(account_id="<accountid>", order_id=order)

print(json.dumps(ed, indent=2, sort_keys=True))
```

Not sure if this is the optimal solution but since buy and sell are working with different parameters (`amount` vs `volume`) having a universal function might be confusing too.