### PR TITLE
Fetch transactions details and fetch note (swedish: avräkningsnota) as a blob

### DIFF
--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -8,7 +8,8 @@ import requests
 
 from .avanza_socket import AvanzaSocket
 from .constants import (ChannelType, HttpMethod, InstrumentType, ListType,
-                        OrderType, Route, TimePeriod, TransactionType)
+                        OrderType, Route, TimePeriod, TransactionType,
+                        TransactionsDetailsType)
 
 BASE_URL = 'https://www.avanza.se'
 MIN_INACTIVE_MINUTES = 30
@@ -87,7 +88,7 @@ class Avanza:
 
         return response_body, credentials
 
-    def __call(self, method: HttpMethod, path: str, options=None):
+    def __call(self, method: HttpMethod, path: str, options=None, return_content: bool = False):
         method_call = {
             HttpMethod.GET: self._session.get,
             HttpMethod.POST: self._session.post,
@@ -119,6 +120,9 @@ class Avanza:
         # only returns 200 OK with no further data about if the operation succeded
         if len(response.content) == 0:
             return None
+
+        if return_content:
+            return response.content
 
         return response.json()
 
@@ -2002,4 +2006,123 @@ class Avanza:
             HttpMethod.GET,
             Route.TRANSACTIONS_PATH.value.format('/'.join(filter(None, [account_id, transaction_type.value if transaction_type else None]))),
             options
+        )
+
+    def get_transactions_details(
+            self,
+            transaction_details_types: Sequence[TransactionsDetailsType]=[],
+            transactions_from: date=None,
+            transactions_to: date=None,
+            isin: str=None,
+            max_elements: int=1000,
+    ):
+        """ Get transactions, optionally apply criterias.
+
+        Args:
+            transaction_types: One or more transaction types.
+
+            transactions_from: Fetch transactions from this date.
+
+            transactions_to: Fetch transactions to this date.
+
+            isin: Only fetch transactions for specified isin.
+
+            max_elements: Limit result to N transactions.
+
+        Returns:
+            {
+                'firstTransactionDate': str,
+                'transactionsFilter': {
+                    'accountIds: null|str,
+                    'dateRange': {
+                        'from': str,
+                        'to': str
+                    }
+                    'isin': null|str,
+                    'transacitonTypes': null|array[str],
+                }
+                'transactionsAfterFiltering' int,
+                'transactions': [
+                    {
+                        'account': {
+                            'type': str,
+                            'name': str,
+                            'id': int,
+                            'urlParameterId': str,
+                        },
+                        'amount': {
+                            'decimalPrecision': int,
+                            'unit': str,
+                            'unitType': str,
+                            'value': int,
+                        },
+                        'availabilityDate': str,
+                        'comission': null|?,
+                        'currencyRate': null|?,
+                        'date': str,
+                        'description': str,
+                        'foreignTaxRate': null|?,
+                        'id': str,
+                        'instrumentName': str,
+                        'intraday': bool,
+                        'isin': str,
+                        'noteId': null|str
+                        'onCreditAccount': bool,
+                        'orderbook': {
+                            'isin': str,
+                            'currency': str,
+                            'flagCode': null|str,
+                            'name': str,
+                            'id': int,
+                            'type': str,
+                            'volumeFactor': int,
+                            'flagCode': null|str,
+                        },
+                        'priceInAccountCurrency': {
+                            'decimalPrecision': int,
+                            'unit': str,
+                            'unitType': str,
+                            'value': float,
+                        },
+                        'priceInTradedCurrency': {
+                            'decimalPrecision': int,
+                            'unit': str,
+                            'unitType': str,
+                            'value': float,
+                        },
+                        'settlementDate: str,
+                        'type': str,
+                        'volume': {
+                            'decimalPrecision': int,
+                            'unit': str,
+                            'unitType': str,
+                            'value': float,
+                        }
+                    },
+                ],
+            }
+        """
+        options = {}
+        options['maxElements'] = max_elements
+
+        if transaction_details_types:
+            options['transactionTypes'] = ','.join(transaction_details_types)
+        if transactions_from:
+            options['from'] = transactions_from.isoformat()
+        if transactions_to:
+            options['to'] = transactions_to.isoformat()
+        if isin:
+            options['isin'] = isin
+
+        return self.__call(
+            HttpMethod.GET,
+            Route.TRANSACTIONS_DETAILS_PATH.value,
+            options
+        )
+
+    def get_note_as_pdf(self, url_parameter_id: str, note_id: str):
+        return self.__call(
+            HttpMethod.GET,
+            Route.NOTE_PATH.value.format(url_parameter_id, note_id),
+            return_content=True
         )

--- a/avanza/constants.py
+++ b/avanza/constants.py
@@ -10,6 +10,14 @@ class TransactionType(enum.Enum):
     INTEREST = 'interest'
     FOREIGN_TAX = 'foreign-tax'
 
+class TransactionsDetailsType(enum.Enum):
+    DIVIDEND = 'DIVIDEND'
+    BUY = 'BUY'
+    SELL = 'SELL'
+    WITHDRAW = 'WITHDRAW'
+    DEPOSIT = 'DEPOSIT'
+    UNKNOWN = 'UNKNOWN'
+
 
 class ChannelType(enum.Enum):
     ACCOUNTS = 'accounts'
@@ -82,6 +90,7 @@ class Route(enum.Enum):
     MONTHLY_SAVINGS_PAUSE_PATH = '/_api/transfer/monthly-savings/{}/{}/pause'
     MONTHLY_SAVINGS_REMOVE_PATH = '/_api/transfer/monthly-savings/{}/{}/'
     MONTHLY_SAVINGS_RESUME_PATH = '/_api/transfer/monthly-savings/{}/{}/resume'
+    NOTE_PATH = '/_api/contract-notes/documents/{}/{}/note.pdf'
     ORDER_DELETE_PATH = '/_api/order?accountId={}&orderId={}'
     ORDER_GET_PATH = '/_mobile/order/{}?accountId={}&orderId={}'
     ORDER_PLACE_PATH = '/_api/order'
@@ -92,5 +101,6 @@ class Route(enum.Enum):
     POSITIONS_PATH = '/_mobile/account/positions'
     TOTP_PATH = '/_api/authentication/sessions/totp'
     TRANSACTIONS_PATH = '/_mobile/account/transactions/{}'
+    TRANSACTIONS_DETAILS_PATH = '/_api/transactions'
     WATCHLISTS_ADD_DELETE_PATH = '/_api/usercontent/watchlist/{}/orderbooks/{}'
     WATCHLISTS_PATH = '/_mobile/usercontent/watchlist'


### PR DESCRIPTION
`get_transactions()` does not return data with `urlParameterId` which is the accountId encrypted by Avanza and also used as one part to fetch the note. Therefore `get_transactions2()` which returns data with `urlParameterId`.

and so we have the `get_note_as_binary_blob(url_parameter_id, note_id)` which returns the pdf as a binary blob.

Would be nice to get feedback fast so we can merge this and hopefully get this released ASAP.
