### PR TITLE
Add endpoint to retrieve existing stop losses

### DIFF
--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -1717,6 +1717,55 @@ class Avanza:
             )
         )
 
+    def get_all_stop_losses(
+        self
+    ):
+        """ Get open stop losses
+
+        Returns:
+            [{
+                "id": str,
+                "status": str,
+                "account": {
+                    "id": str,
+                    "name": str,
+                    "type": str,
+                    "urlParameterId": str
+                },
+                "orderbook": {
+                    "id": str,
+                    "name": str,
+                    "countryCode": str,
+                    "currency": str,
+                    "shortName": str,
+                    "type": str
+                },
+                "hasExcludingChildren": bool,
+                "message": str,
+                "trigger": {
+                    "value": int,
+                    "type": str,
+                    "validUntil": str,
+                    "valueType": str
+                },
+                "order": {
+                    "type": str,
+                    "price": int,
+                    "volume": int,
+                    "shortSellingAllowed": bool,
+                    "validDays": int,
+                    "priceType": str,
+                    "priceDecimalPrecision": 0
+                },
+                "editable": bool,
+                "deletable": bool
+            }]
+        """
+        return self.__call(
+            HttpMethod.GET,
+            Route.STOP_LOSS_PATH.value
+        )
+
     def delete_order(
         self,
         account_id: str,

--- a/avanza/constants.py
+++ b/avanza/constants.py
@@ -102,6 +102,7 @@ class Route(enum.Enum):
     OVERVIEW_PATH = '/_mobile/account/overview'
     POSITIONS_PATH = '/_mobile/account/positions'
     PRICE_ALERT_PATH = '/_cqbe/marketing/service/alert/{}'
+    STOP_LOSS_PATH = '/_cqbe/trading/stoploss'
     TOTP_PATH = '/_api/authentication/sessions/totp'
     TRANSACTIONS_PATH = '/_mobile/account/transactions/{}'
     TRANSACTIONS_DETAILS_PATH = '/_api/transactions'


### PR DESCRIPTION
Hi! I'm in the process of automating the update of my stop losses on Avanza and the first step in my automation is that I need to check my existing stop losses. Is that something you want to have merged here as well? The next step (another PR later this month) is another endpoint to actually be able to create new stops and delete existing ones.

Thanks for the lib!

Example of a real response using the code from this PR:
![image](https://user-images.githubusercontent.com/196840/133478633-a7d3fbf6-9df7-4113-915e-50668ad6813d.png)
