### PR TITLE
Update API endpoint for order place path

### DIFF
--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -1512,10 +1512,9 @@ class Avanza:
 
         Returns:
             {
-                messages: List[str],
+                message: str,
                 orderId: str,
-                requestId: str,
-                status: str
+                orderRequestStatus: str
             }
         """
 

--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -1525,7 +1525,7 @@ class Avanza:
             {
                 'accountId': account_id,
                 'orderbookId': order_book_id,
-                'orderType': order_type.value,
+                'side': order_type.value,
                 'price': price,
                 'validUntil': valid_until.isoformat(),
                 'volume': volume

--- a/avanza/constants.py
+++ b/avanza/constants.py
@@ -90,7 +90,6 @@ class HttpMethod(enum.Enum):
     PUT = 3
     DELETE = 4
 
-
 class Route(enum.Enum):
     ACCOUNT_OVERVIEW_PATH = '/_mobile/account/{}/overview'
     ACCOUNTS_POSITIONS_PATH = '/_cqbe/ff/overview/positions'
@@ -109,7 +108,7 @@ class Route(enum.Enum):
     NOTE_PATH = '/_api/contract-notes/documents/{}/{}/note.pdf'
     ORDER_DELETE_PATH = '/_api/order?accountId={}&orderId={}'
     ORDER_GET_PATH = '/_mobile/order/{}?accountId={}&orderId={}'
-    ORDER_PLACE_PATH = '/_api/order'
+    ORDER_PLACE_PATH = '/_cqbe/trading/order/new'
     ORDER_PLACE_PATH_BUY_FUND = '/_api/fund-guide/fund-order-page/buy'
     ORDER_PLACE_PATH_SELL_FUND = '/_api/fund-guide/fund-order-page/sell'
     ORDER_EDIT_PATH = '/_api/order/{}/{}'


### PR DESCRIPTION
Fixes #47 

Return of this new endpoint is different from before:

```
{'orderRequestStatus': 'SUCCESS', 'message': '', 'orderId': 'NNNNNN'}
```