### PR TITLE
Fix login error when two factor is disabled

### DIFF
--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -71,7 +71,8 @@ class Avanza:
 
         # No second factor required, continue with normal login
         if response_body.get('twoFactorLogin') is None:
-            return response_body, credentials
+            self._security_token = response.headers.get('X-SecurityToken')
+            return response_body['successfulLogin'], credentials
 
         tfa_method = response_body['twoFactorLogin'].get('method')
 


### PR DESCRIPTION
When 2fa is disabled the response object is inside an extra level called "successfulLogin". Also security token was not saved as it was when using 2fa.