### PR TITLE
Break out Credentials to a class

### DIFF
--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -1,8 +1,6 @@
-import hashlib
 from datetime import date
-from typing import Any, Callable, Dict, List, Optional, Sequence, TypedDict, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
-import pyotp
 import requests
 
 from avanza.entities import StopLossOrderEvent, StopLossTrigger

--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -21,23 +21,21 @@ from .constants import (
     TimePeriod,
     TransactionsDetailsType,
 )
+from .credentials import BaseCredentials, backwards_compatible_serialization
 
 BASE_URL = "https://www.avanza.se"
 MIN_INACTIVE_MINUTES = 30
 MAX_INACTIVE_MINUTES = 60 * 24
 
 
-class Credentials(TypedDict):
-    username: str
-    password: str
-    totpSecret: str
-
 
 class Avanza:
-    def __init__(self, credentials: Credentials):
+    def __init__(self, credentials: Union[BaseCredentials, Dict[str, str]]):
         """
         Args:
-            credentials: Login credentials.
+            credentials: Login credentials. Can be mulitple variations
+                Either an instance of TokenCredentials or of SecretCredentials
+                Or a dictionary as the following:
                 Using TOTP secret:
                     {
                         'username': 'MY_USERNAME',
@@ -51,6 +49,9 @@ class Avanza:
                         'totpCode': 'MY_TOTP_CODE'
                     }
         """
+        if isinstance(credentials, dict):
+            credentials: BaseCredentials = backwards_compatible_serialization(credentials)
+
         self._authenticationTimeout = MAX_INACTIVE_MINUTES
         self._session = requests.Session()
 
@@ -65,11 +66,11 @@ class Avanza:
             self._push_subscription_id, self._session.cookies.get_dict()
         )
 
-    def __authenticate(self, credentials: Credentials):
+    def __authenticate(self, credentials: BaseCredentials):
         if (
-            not MIN_INACTIVE_MINUTES
-            <= self._authenticationTimeout
-            <= MAX_INACTIVE_MINUTES
+                not MIN_INACTIVE_MINUTES
+                    <= self._authenticationTimeout
+                    <= MAX_INACTIVE_MINUTES
         ):
             raise ValueError(
                 f"Session timeout not in range {MIN_INACTIVE_MINUTES} - {MAX_INACTIVE_MINUTES} minutes"
@@ -77,8 +78,8 @@ class Avanza:
 
         data = {
             "maxInactiveMinutes": self._authenticationTimeout,
-            "username": credentials["username"],
-            "password": credentials["password"],
+            "username": credentials.username,
+            "password": credentials.password,
         }
 
         response = self._session.post(
@@ -101,16 +102,10 @@ class Avanza:
 
         return self.__validate_2fa(credentials)
 
-    def __validate_2fa(self, credentials: Credentials):
-        if "totpSecret" in credentials:
-            totp = pyotp.TOTP(credentials["totpSecret"], digest=hashlib.sha1)
-            totp_code = totp.now()
-        elif "totpCode" in credentials:
-            totp_code = credentials["totpCode"]
-
+    def __validate_2fa(self, credentials: BaseCredentials):
         response = self._session.post(
             f"{BASE_URL}{Route.TOTP_PATH.value}",
-            json={"method": "TOTP", "totpCode": totp_code},
+            json={"method": "TOTP", "totpCode": credentials.totp_code},
         )
 
         response.raise_for_status()

--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -31,7 +31,7 @@ class Avanza:
     def __init__(self, credentials: Union[BaseCredentials, Dict[str, str]]):
         """
         Args:
-            credentials: Login credentials. Can be mulitple variations
+            credentials: Login credentials. Can be multiple variations
                 Either an instance of TokenCredentials or of SecretCredentials
                 Or a dictionary as the following:
                 Using TOTP secret:

--- a/avanza/credentials.py
+++ b/avanza/credentials.py
@@ -1,0 +1,66 @@
+from typing import Dict
+
+from pydantic import BaseModel, Field
+import pyotp
+import hashlib
+import abc
+
+
+class BaseCredentials(BaseModel, abc.ABC):
+    username: str
+    password: str
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @property
+    @abc.abstractmethod
+    def totp_code(self) -> str:
+        pass
+
+    @classmethod
+    def __init_subclass__(cls, **kwargs):
+        if cls is BaseCredentials:
+            raise TypeError("Cannot instantiate BaseCredentials directly")
+        super().__init_subclass__(**kwargs)
+
+
+class SecretCredentials(BaseCredentials):
+    # It would've been nice to let this be a private var
+    # but all pydantic versions don't support multiple aliases,
+    # so we can't use both snake case and camel case then
+    totp_secret: str = Field(..., alias="totpSecret")
+
+    class Config:
+        allow_mutation = False
+
+    @property
+    def totp_code(self) -> str:
+        return pyotp.TOTP(self.totp_secret, digest=hashlib.sha1).now()
+
+
+class TokenCredentials(BaseCredentials):
+    # It would've been nice to let this be a private var
+    # but all pydantic versions don't support multiple aliases,
+    # so we can't use both snake case and camel case then
+    totp_token: str = Field(..., alias="totpToken")
+
+    class Config:
+        allow_mutation = False
+
+    @property
+    def totp_code(self):
+        return self.totp_token
+
+
+def backwards_compatible_serialization(d: Dict[str, str]) -> BaseCredentials:
+    """
+    Will try to find the correct subclass based on which totp method is supplied,
+    throws ValueError if none is present
+    """
+    keys = d.keys()
+    if "totp_secret" in keys or "totpSecret" in keys:
+        return SecretCredentials(**d)
+    if "totp_token" in keys or "totpToken" in keys:
+        return TokenCredentials(**d)
+    raise ValueError("Could not find totp_secret or totp_token")


### PR DESCRIPTION
So I saw that you started to break out models and such. I've broken out Credentials  to `SecretCredentials`  and `TokenCredentials` which inherent from `BaseCredentials`.  I wrote a serializer from dictionary so that API is still backwards compatible. 