### PR TITLE
[#103]: Extend StopLossTrigger model.

### DIFF
--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -26,6 +26,7 @@ MIN_INACTIVE_MINUTES = 30
 MAX_INACTIVE_MINUTES = 60 * 24
 
 
+
 class Avanza:
     def __init__(self, credentials: Union[BaseCredentials, Dict[str, str]]):
         """
@@ -47,9 +48,7 @@ class Avanza:
                     }
         """
         if isinstance(credentials, dict):
-            credentials: BaseCredentials = backwards_compatible_serialization(
-                credentials
-            )
+            credentials: BaseCredentials = backwards_compatible_serialization(credentials)
 
         self._authenticationTimeout = MAX_INACTIVE_MINUTES
         self._session = requests.Session()
@@ -67,9 +66,9 @@ class Avanza:
 
     def __authenticate(self, credentials: BaseCredentials):
         if (
-            not MIN_INACTIVE_MINUTES
-            <= self._authenticationTimeout
-            <= MAX_INACTIVE_MINUTES
+                not MIN_INACTIVE_MINUTES
+                    <= self._authenticationTimeout
+                    <= MAX_INACTIVE_MINUTES
         ):
             raise ValueError(
                 f"Session timeout not in range {MIN_INACTIVE_MINUTES} - {MAX_INACTIVE_MINUTES} minutes"

--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -26,7 +26,6 @@ MIN_INACTIVE_MINUTES = 30
 MAX_INACTIVE_MINUTES = 60 * 24
 
 
-
 class Avanza:
     def __init__(self, credentials: Union[BaseCredentials, Dict[str, str]]):
         """
@@ -48,7 +47,9 @@ class Avanza:
                     }
         """
         if isinstance(credentials, dict):
-            credentials: BaseCredentials = backwards_compatible_serialization(credentials)
+            credentials: BaseCredentials = backwards_compatible_serialization(
+                credentials
+            )
 
         self._authenticationTimeout = MAX_INACTIVE_MINUTES
         self._session = requests.Session()
@@ -66,9 +67,9 @@ class Avanza:
 
     def __authenticate(self, credentials: BaseCredentials):
         if (
-                not MIN_INACTIVE_MINUTES
-                    <= self._authenticationTimeout
-                    <= MAX_INACTIVE_MINUTES
+            not MIN_INACTIVE_MINUTES
+            <= self._authenticationTimeout
+            <= MAX_INACTIVE_MINUTES
         ):
             raise ValueError(
                 f"Session timeout not in range {MIN_INACTIVE_MINUTES} - {MAX_INACTIVE_MINUTES} minutes"
@@ -557,6 +558,8 @@ class Avanza:
                     "type": stop_loss_trigger.type.value,
                     "value": stop_loss_trigger.value,
                     "validUntil": stop_loss_trigger.valid_until.isoformat(),
+                    "valueType": stop_loss_trigger.value_type.value,
+                    "triggerOnMarketMakerQuote": stop_loss_trigger.trigger_on_market_maker_quote,
                 },
                 "stopLossOrderEvent": {
                     "type": stop_loss_order_event.type.value,

--- a/avanza/entities.py
+++ b/avanza/entities.py
@@ -5,10 +5,19 @@ from .constants import OrderType, StopLossPriceType, StopLossTriggerType
 
 
 class StopLossTrigger:
-    def __init__(self, type: StopLossTriggerType, value: float, valid_until: date):
+    def __init__(
+        self,
+        type: StopLossTriggerType,
+        value: float,
+        valid_until: date,
+        value_type: StopLossPriceType,
+        trigger_on_market_maker_quote: bool = False,
+    ):
         self.type = type
         self.value = value
         self.valid_until = valid_until
+        self.value_type = value_type
+        self.trigger_on_market_maker_quote = trigger_on_market_maker_quote
 
 
 class StopLossOrderEvent:


### PR DESCRIPTION
Close #103 . 

# Overview

Extend `StopLossTrigger` to  use `valueType` and `triggerOnMarketMakerQuote`. 

Require `valueType` 
Optional `triggerOnMarketMakerQuote` (Defaults to False)


# Avanza API endpoint call

`POST to https://www.avanza.se/_api/trading-critical/rest/stoploss/new`

``` json
...
"stopLossTrigger":
{"type":"FOLLOW_UPWARDS",
"value":15,
"valueType":"PERCENTAGE",
"validUntil":"2024-07-19",
"triggerOnMarketMakerQuote":false
}
...
```