### PR TITLE
fix: Replace deprecated 'allow_mutation' with 'frozen' in Pydantic mo…

### DIFF
--- a/avanza/credentials.py
+++ b/avanza/credentials.py
@@ -32,7 +32,7 @@ class SecretCredentials(BaseCredentials):
     totp_secret: str = Field(..., alias="totpSecret")
 
     class Config:
-        allow_mutation = False
+        frozen = True
 
     @property
     def totp_code(self) -> str:
@@ -46,7 +46,7 @@ class TokenCredentials(BaseCredentials):
     totp_token: str = Field(..., alias="totpToken")
 
     class Config:
-        allow_mutation = False
+        frozen = True
 
     @property
     def totp_code(self):


### PR DESCRIPTION
…dels

Updated the configuration in Pydantic models to use 'frozen' instead of the deprecated 'allow_mutation' to ensure compatibility with Pydantic V2.