### PR TITLE
Allow async callbacks on subscriptions

### DIFF
--- a/avanza/avanza_socket.py
+++ b/avanza/avanza_socket.py
@@ -177,7 +177,10 @@ class AvanzaSocket:
             # Use user subscribed action
             if action is None:
                 callback = self._subscriptions[message_channel]["callback"]
-                callback(message)
+                if asyncio.iscoroutinefunction(callback):
+                    await callback(message)
+                else:
+                    callback(message)
             else:
                 await action(message)
 


### PR DESCRIPTION
Support async callbacks in the same way as non-async callback.

```python
async def async_callback(data):
    print(data)

avanza_client.subscribe_to_id(
                ChannelType.QUOTES,
                "19002",
                asynccallback
            )

```