### PR TITLE
Added analysis information for an instrument

### DIFF
--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -267,6 +267,15 @@ class Avanza:
         # Works when sending InstrumentType.STOCK, but not InstrumentType.INDEX
         return self.get_instrument(InstrumentType.STOCK, index_id)
 
+    def get_analysis(self,instrument_id: str ):
+         """Returns analysis data for an instrument """
+        return self.__call(
+            HttpMethod.GET,
+            Route.ANALYSIS_PATH.value.format(
+                instrument_id
+            )
+        )
+    
     def get_instrument(self, instrument_type: InstrumentType, instrument_id: str):
         """
         Get instrument info

--- a/avanza/constants.py
+++ b/avanza/constants.py
@@ -126,6 +126,7 @@ class Route(enum.Enum):
     ACCOUNT_PERFORMANCE_CHART_PATH = (
         "/_api/account-performance/overview/chart/accounts/timeperiod"
     )
+    ANALYSIS_PATH = '/_api/market-guide/stock/{}/analysis'
     AUTHENTICATION_PATH = "/_api/authentication/sessions/usercredentials"
     CATEGORIZED_ACCOUNTS = "/_api/account-overview/overview/categorizedAccounts"
     CHARTDATA_PATH = "/_api/price-chart/stock/{}"


### PR DESCRIPTION
Fixes at least part of  #120 

To get analysis data fro ABB call:

avanza.get_analysis(5447)

Returns a lot of analysis data:
{'stockKeyRatiosByYear': {'priceEarningsRatio': [{'date': '2019-02-28', 'reportType': 'FULL_YEAR', 'financialYear': 2018, 'value': 18.69}, {'date': '2020-02-05', 'reportType': 'FULL_YEAR', 'financialYear': 2019, 'value': 33.58}, {'date': '2021-02-04', 'reportType': 'FULL_YEAR', 'financialYear': 2020, 'value': 170.71}, {'date': '2022-02-03', 'reportType': 'FULL_YEAR', 'financialYear': 2021, ...

