### PR TITLE
Fix avanza_socket.py's __create_socket to work with latest websockets version

### DIFF
--- a/avanza/avanza_socket.py
+++ b/avanza/avanza_socket.py
@@ -44,7 +44,7 @@ class AvanzaSocket:
 
     async def __create_socket(self):
         async with websockets.connect(
-            WEBSOCKET_URL, extra_headers={"Cookie": self._cookies}
+            WEBSOCKET_URL, additional_headers={"Cookie": self._cookies}
         ) as self._socket:
             await self.__send_handshake_message()
             await self.__socket_message_handler()


### PR DESCRIPTION
Closes #132 by replacing `async with websockets.connect(WEBSOCKET_URL, extra_headers={"Cookie": self._cookies}) as self._socket:` with `async with websockets.connect(WEBSOCKET_URL, additional_headers={"Cookie": self._cookies}) as self._socket:`
