### PR TITLE
Change the get_insights_report call from GET to POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ avanza = Avanza({
 })
 
 report = avanza.get_insights_report(
-    account_id='XXXXXXX',
+    account_ids=['XXXXXXX'],
     time_period=TimePeriod.ONE_WEEK
 )
 ```

--- a/avanza/avanza.py
+++ b/avanza/avanza.py
@@ -454,12 +454,13 @@ class Avanza:
         )
 
     def get_insights_report(
-        self, account_id: str, time_period: InsightsReportTimePeriod
+        self, account_ids: list[str], time_period: InsightsReportTimePeriod
     ) -> InsightsReport:
         """Get report about the development of your owned positions during the specified timeperiod"""
         return self.__call(
-            HttpMethod.GET,
-            Route.INSIGHTS_PATH.value.format(time_period.value, account_id),
+            HttpMethod.POST,
+            Route.INSIGHTS_PATH.value,
+            options={"timePeriod": time_period.value, "accountIds": account_ids},
         )
 
     def get_deals(self):

--- a/avanza/constants.py
+++ b/avanza/constants.py
@@ -131,7 +131,7 @@ class Route(enum.Enum):
     ORDERS_PATH = "/_api/trading/rest/orders"
     FORUM_PATH = "/_api/market-guide/forum/{}"
     FUND_PATH = "/_api/fund-guide/guide/{}"
-    INSIGHTS_PATH = "/_api/insights-development/?timePeriod={}&accountIds={}"
+    INSIGHTS_PATH = "/_api/insights-development/insights"
     INSPIRATION_LIST_PATH = "/_mobile/marketing/inspirationlist/{}"
     INSTRUMENT_PATH = "/_api/market-guide/{}/{}"
     INSTRUMENT_DETAILS_PATH = "/_api/market-guide/{}/{}/details"

--- a/avanza/models/insights_report.py
+++ b/avanza/models/insights_report.py
@@ -112,4 +112,3 @@ class InsightsReport(BaseModel):
     """ YYYY-MM-DD """
     toDate: str
     """ YYYY-MM-DD """
-    aggregatedPerformance: Union[float, Literal["-"]]

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -249,7 +249,7 @@ class ReturnModelTest(unittest.TestCase):
         for time_period in InsightsReportTimePeriod:
             with self.subTest(time_period=time_period):
                 insights_report = get_or_cache(
-                    self.avanza.get_insights_report, [account_id, time_period]
+                    self.avanza.get_insights_report, [[account_id], time_period]
                 )
 
                 try:


### PR DESCRIPTION
The method for the "insights-development" seems to have changed from GET to POST recently. The endpoint also allows requesting a report for multiple accounts.