### PR TITLE
feat: add strict read-only Avanza wrapper

### DIFF
--- a/avanza/readonly_avanza.py
+++ b/avanza/readonly_avanza.py
@@ -1,0 +1,103 @@
+"""
+readonly_avanza.py — Strict read-only wrapper around the Avanza client.
+
+Exposes only safe read methods. Write/mutate methods are NOT accessible.
+Designed for use by OpenClaw (or any automated agent) where accidental
+order placement or account mutation must be impossible.
+
+Usage:
+    from avanza import Avanza
+    from readonly_avanza import ReadOnlyAvanza
+
+    client = Avanza(credentials={...})  # you own the auth
+    ro = ReadOnlyAvanza(client)
+
+    overview   = ro.get_overview()    # dict
+    positions  = ro.get_positions()   # dict
+    watchlists = ro.get_watchlists()  # list of dicts
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def _to_json_safe(obj: Any) -> Any:
+    """Recursively convert an object to plain JSON-safe Python types."""
+    if isinstance(obj, dict):
+        return {k: _to_json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_to_json_safe(v) for v in obj]
+    # Pydantic / dataclass models expose __dict__ or model_dump
+    if hasattr(obj, "model_dump"):
+        return _to_json_safe(obj.model_dump())
+    if hasattr(obj, "__dict__"):
+        return _to_json_safe(vars(obj))
+    # Scalars that are JSON-safe
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+    # Fallback: stringify anything else (e.g. Decimal, date)
+    return str(obj)
+
+
+class ReadOnlyAvanza:
+    """
+    A strict read-only façade over the Avanza client.
+
+    Only the three approved read methods are exposed.
+    No write, mutate, order, or delete methods are accessible.
+    All return values are plain JSON-safe dicts/lists.
+    """
+
+    # The three public names this wrapper exposes.
+    # __getattr__ is only invoked when normal attribute lookup fails, so
+    # these explicit methods take priority. The allowlist is used solely
+    # to produce a helpful error message for any other attribute access.
+    _ALLOWED_METHODS = frozenset({"get_overview", "get_positions", "get_watchlists"})
+
+    def __init__(self, client: Any) -> None:
+        # Store the underlying client in a name-mangled attribute so it
+        # cannot be trivially accessed as `wrapper._client`.
+        object.__setattr__(self, "_ReadOnlyAvanza__client", client)
+
+    # ------------------------------------------------------------------
+    # Attribute guard — prevent any access not in the allowlist
+    # ------------------------------------------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        # This is only reached for attributes not found via normal lookup
+        # (i.e. NOT get_overview / get_positions / get_watchlists, which are
+        # defined explicitly below and always resolve before __getattr__).
+        raise AttributeError(
+            f"'{type(self).__name__}' does not expose '{name}'. "
+            "Only these read methods are available: "
+            + ", ".join(sorted(self._ALLOWED_METHODS))
+        )
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError(
+            f"'{type(self).__name__}' is read-only and does not support attribute assignment."
+        )
+
+    # ------------------------------------------------------------------
+    # Explicit read methods
+    # ------------------------------------------------------------------
+
+    def get_overview(self) -> Dict[str, Any]:
+        """Return account overview as a plain dict."""
+        client = object.__getattribute__(self, "_ReadOnlyAvanza__client")
+        return _to_json_safe(client.get_overview())
+
+    def get_positions(self) -> Dict[str, Any]:
+        """Return current positions as a plain dict.
+
+        Delegates to client.get_accounts_positions() — the only positions
+        method on the underlying Avanza client.
+        """
+        client = object.__getattribute__(self, "_ReadOnlyAvanza__client")
+        return _to_json_safe(client.get_accounts_positions())
+
+    def get_watchlists(self) -> List[Dict[str, Any]]:
+        """Return watchlists as a plain list of dicts."""
+        client = object.__getattribute__(self, "_ReadOnlyAvanza__client")
+        return _to_json_safe(client.get_watchlists())

--- a/avanza/test_readonly_avanza.py
+++ b/avanza/test_readonly_avanza.py
@@ -1,0 +1,117 @@
+"""
+test_readonly_avanza.py — Tests for ReadOnlyAvanza wrapper.
+
+Verifies:
+  1. Approved read methods are accessible.
+  2. Write / mutate methods are blocked.
+  3. Return values are plain JSON-safe types (no custom objects).
+  4. Direct attribute assignment is blocked.
+  5. The underlying client cannot be accessed through the wrapper.
+
+No real credentials are used — a mock client stands in for Avanza.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from readonly_avanza import ReadOnlyAvanza
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.get_overview.return_value = {"totalOwnCapital": 100000, "accounts": []}
+    client.get_accounts_positions.return_value = {"withOrderbook": [], "withoutOrderbook": []}
+    client.get_watchlists.return_value = [{"id": "123", "name": "My watchlist", "orderbooks": []}]
+    return client
+
+@pytest.fixture
+def ro(mock_client):
+    return ReadOnlyAvanza(mock_client)
+
+
+class TestReadMethodsExposed:
+    def test_get_overview_exists(self, ro):
+        assert callable(getattr(ro, "get_overview", None))
+
+    def test_get_positions_exists(self, ro):
+        assert callable(getattr(ro, "get_positions", None))
+
+    def test_get_watchlists_exists(self, ro):
+        assert callable(getattr(ro, "get_watchlists", None))
+
+    def test_get_overview_returns_dict(self, ro):
+        result = ro.get_overview()
+        assert isinstance(result, dict)
+
+    def test_get_positions_returns_dict(self, ro):
+        result = ro.get_positions()
+        assert isinstance(result, dict)
+
+    def test_get_watchlists_returns_list(self, ro):
+        result = ro.get_watchlists()
+        assert isinstance(result, list)
+
+
+WRITE_METHODS = [
+    "place_order", "place_order_buy_fund", "place_order_sell_fund",
+    "place_stop_loss_order", "edit_order", "delete_order",
+    "delete_stop_loss_order", "add_to_watchlist", "remove_from_watchlist",
+    "create_monthly_saving", "delete_monthly_saving", "pause_monthly_saving",
+    "resume_monthly_saving", "set_price_alert", "delete_price_alert",
+]
+
+class TestWriteMethodsBlocked:
+    @pytest.mark.parametrize("method_name", WRITE_METHODS)
+    def test_write_method_raises(self, ro, method_name):
+        with pytest.raises(AttributeError):
+            getattr(ro, method_name)
+
+    def test_hasattr_returns_false_for_place_order(self, ro):
+        assert not hasattr(ro, "place_order")
+
+    def test_hasattr_returns_false_for_delete_order(self, ro):
+        assert not hasattr(ro, "delete_order")
+
+    def test_hasattr_returns_false_for_edit_order(self, ro):
+        assert not hasattr(ro, "edit_order")
+
+
+class TestJsonSafeReturns:
+    def _is_json_safe(self, obj):
+        if isinstance(obj, (str, int, float, bool, type(None))):
+            return True
+        if isinstance(obj, dict):
+            return all(isinstance(k, str) and self._is_json_safe(v) for k, v in obj.items())
+        if isinstance(obj, list):
+            return all(self._is_json_safe(v) for v in obj)
+        return False
+
+    def test_overview_is_json_safe(self, ro):
+        assert self._is_json_safe(ro.get_overview())
+
+    def test_positions_is_json_safe(self, ro):
+        assert self._is_json_safe(ro.get_positions())
+
+    def test_watchlists_is_json_safe(self, ro):
+        assert self._is_json_safe(ro.get_watchlists())
+
+
+class TestImmutability:
+    def test_cannot_set_attribute(self, ro):
+        with pytest.raises(AttributeError):
+            ro.some_new_attr = "value"
+
+    def test_cannot_overwrite_read_method(self, ro):
+        with pytest.raises(AttributeError):
+            ro.get_overview = lambda: {}
+
+
+class TestClientNotExposed:
+    def test_client_attribute_blocked(self, ro):
+        with pytest.raises(AttributeError):
+            _ = ro._client
+
+    def test_no_raw_client_shortcut(self, ro):
+        for attr in ("client", "avanza", "_avanza", "wrapped"):
+            assert not hasattr(ro, attr)


### PR DESCRIPTION
## What this PR does
Adds a minimal strict read-only wrapper for Avanza usage in OpenClaw-style agent setups.

## Changes
- adds readonly_avanza.py
- exposes only:
  - get_overview()
  - get_positions()
  - get_watchlists()
- blocks access to non-exposed methods via attribute guard
- converts return values to plain JSON-safe Python types
- adds tests in test_readonly_avanza.py

## Verification
- local tests passed: 31 passed

## Notes
- no credentials added
- no OpenClaw runtime integration yet
- no write/order/delete methods exposed